### PR TITLE
feat: test on Node.js v10, v12, and v14

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,27 @@
+name: nodejs
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [10, 12, 14]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - name: Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2.1.1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Update npm
+      run: |
+        npm install -g npm
+        npm --version
+    - uses: actions/checkout@v2.3.2
+    - name: Install dependencies
+      uses: bahmutov/npm-install@v1.4.3
+      with:
+        useLockFile: false
+    - name: npm ls
+      run: npm ls
+    - name: Test
+      run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "4"
-before_install:
-  - npm install -g npm
-  - npm --version
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # sig-floor
 
-[![Build Status][travis-svg]][travis]
-
 Round a number down (towards zero) to the nearest multiple of significance.
 This is just like the `FLOOR` function in Microsoft Excel.
 
@@ -43,7 +41,3 @@ var sigFloor = require('sig-floor');
 
 Given the _Number_ `number` that you want to round, returns the floor of
 `number` to the _Number_ `significance` multiple.
-
-
-   [travis]: https://travis-ci.org/KenanY/sig-floor
-   [travis-svg]: https://img.shields.io/travis/KenanY/sig-floor.svg

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "directories": {
     "test": "test"
   },
+  "engines": {
+    "node": "10 || 12 || >=14"
+  },
   "scripts": {
     "pretest": "eslint index.js test/index.js",
     "test": "tape test/index.js"


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is now the minimum supported version of
Node.js.